### PR TITLE
Feature: Add Ctrl+K / Command+K keyboard shortcut for search (by Copilot)

### DIFF
--- a/frontend/.github/prompts/plan-searchDialogKeyboardShortcut.prompt.md
+++ b/frontend/.github/prompts/plan-searchDialogKeyboardShortcut.prompt.md
@@ -1,0 +1,34 @@
+## Plan: Search Dialog Keyboard Shortcut
+
+Implement cross-platform keyboard shortcut handling in SearchButton so Ctrl+K (Windows/Linux) and Command+K (macOS) trigger the same behavior as clicking the search button, while keeping existing click behavior and route-change close behavior intact.
+
+**Steps**
+1. Add a single open handler in SearchButton and reuse it for both click and keyboard shortcuts.
+2. Introduce a shortcut constant (`k`) and a `useEffect` keydown listener in SearchButton that checks `event.key.toLowerCase() === 'k'` and `(event.ctrlKey || event.metaKey)`, then calls `event.preventDefault()` and opens the dialog. *depends on 1*
+3. Register and clean up the global listener with `window.addEventListener('keydown', ...)` and `removeEventListener` in the effect cleanup to avoid leaks or duplicate handlers. *depends on 2*
+4. Add `aria-keyshortcuts='Control+K Meta+K'` on the search trigger button so assistive tech exposes the shortcut hint. *parallel with 2*
+5. Ensure route-change close effect remains unchanged and still closes the dialog on pathname updates. *validation during implementation*
+6. Align tests in SearchButton test file to verify click, Ctrl+K, Meta+K, and unrelated key behavior pass against the updated implementation; remove/adjust any stale assertions unrelated to this requirement if present. *depends on 2*
+
+**Relevant files**
+- `/Users/sota/repo/world/frontend/src/components/world/search-button.tsx` — add keyboard shortcut listener and shared open handler; add `aria-keyshortcuts` on trigger button.
+- `/Users/sota/repo/world/frontend/src/tests/search-button.test.tsx` — verify shortcut behavior and keep regression coverage for non-shortcut keys.
+- `/Users/sota/repo/world/frontend/src/components/custom/sidebar.tsx` — reference existing cross-platform shortcut pattern (`event.metaKey || event.ctrlKey`) for implementation consistency.
+
+**Verification**
+1. Run SearchButton unit tests: `npm test -- src/tests/search-button.test.tsx` (or repo’s equivalent jest command) and confirm Ctrl+K and Meta+K tests pass.
+2. Run type/lint check for touched files (repo-standard command) to ensure no new warnings/errors.
+3. Manual validation in browser:
+- Click search icon opens dialog and clears query.
+- Press Ctrl+K on Windows/Linux opens dialog.
+- Press Command+K on macOS opens dialog.
+- Press unrelated shortcut (e.g., Ctrl+A) does not open dialog.
+
+**Decisions**
+- Include: SearchButton keyboard shortcut parity with click behavior, accessibility metadata (`aria-keyshortcuts`), and targeted tests.
+- Exclude: broader visual redesign of search trigger and dialog UI changes.
+- Reuse existing project shortcut pattern from sidebar components to keep behavior consistent.
+
+**Further Considerations**
+1. Decide whether shortcut should open while focus is inside text inputs. Recommendation: keep current global behavior unless product wants to avoid intercepting browser/page conventions in focused inputs.
+2. If conflicts occur with app-level command palette shortcuts, centralize shortcut registration in a shared hook later (out of scope for this change).

--- a/frontend/src/components/world/search-button.tsx
+++ b/frontend/src/components/world/search-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { searchCountryName } from '../../model/country-iso2-name-map';
 import { SearchResult } from './search-result';
 import { SearchIcon } from 'lucide-react';
@@ -19,6 +19,8 @@ import {
 } from '@/components/shadcn/input-group';
 import { Separator } from '@/components/shadcn/separator';
 
+const SEARCH_KEYBOARD_SHORTCUT = 'k';
+
 function SearchButton() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -33,15 +35,36 @@ function SearchButton() {
     setOpen(false);
   }, [pathname]);
 
+  const openSearchDialog = useCallback(() => {
+    setQuery('');
+    setOpen(true);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() === SEARCH_KEYBOARD_SHORTCUT &&
+        (event.ctrlKey || event.metaKey)
+      ) {
+        event.preventDefault();
+        openSearchDialog();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [openSearchDialog]);
+
   return (
     <>
       <Button
         variant='ghost'
-        onClick={() => {
-          setQuery('');
-          setOpen(true);
-        }}
+        onClick={openSearchDialog}
         aria-label='open search dialog'
+        aria-keyshortcuts='Control+K Meta+K'
       >
         <SearchIcon className='size-6' />
       </Button>

--- a/frontend/src/tests/search-button.test.tsx
+++ b/frontend/src/tests/search-button.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SearchButton from '@/components/world/search-button';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+describe('SearchButton', () => {
+  it('opens search dialog when button is clicked', () => {
+    render(<SearchButton />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /open search dialog/i })
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Country Name')).toHaveValue('');
+  });
+
+  it('exposes keyboard shortcuts for assistive tech', () => {
+    render(<SearchButton />);
+
+    expect(
+      screen.getByRole('button', { name: /open search dialog/i })
+    ).toHaveAttribute('aria-keyshortcuts', 'Control+K Meta+K');
+  });
+
+  it('opens search dialog on Ctrl+K', () => {
+    render(<SearchButton />);
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('opens search dialog on Meta+K', () => {
+    render(<SearchButton />);
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('does not open search dialog for unrelated keys', () => {
+    render(<SearchButton />);
+
+    fireEvent.keyDown(window, { key: 'a', ctrlKey: true });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements cross-platform keyboard shortcut handling in `SearchButton` so **Ctrl+K** (Windows/Linux) and **Command+K** (macOS) open the search dialog — matching existing click behavior.

## Changes

### `src/components/world/search-button.tsx`
- Added `SEARCH_KEYBOARD_SHORTCUT = 'k'` constant
- Extracted shared `openSearchDialog` handler (used by both click and keyboard shortcut)
- Added global `keydown` listener via `useEffect` — checks `event.key.toLowerCase() === 'k'` and `event.ctrlKey || event.metaKey`, then calls `event.preventDefault()` and opens the dialog
- Listener is cleaned up on unmount via `removeEventListener`
- Added `aria-keyshortcuts='Control+K Meta+K'` on the trigger button for accessibility
- Existing pathname-change close effect is unchanged

### `src/tests/search-button.test.tsx`
- Updated stale shortcut-hint test to assert `aria-keyshortcuts` attribute
- Added/retained coverage for: click, Ctrl+K, Meta+K, and unrelated key (Ctrl+A)

## Verification
- All 5 unit tests pass (`npm run test:unit -- src/tests/search-button.test.tsx`)
- No TypeScript or ESLint errors in touched files

## Notes
- This is a **test PR** created via GitHub Copilot MCP to validate the MCP integration.