### PR TITLE
Feature: Add global error boundary page

### DIFF
--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Button } from '@/components/shadcn/button';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div className='flex flex-col items-center justify-center gap-4'>
+      <h1>Oops, Something went wrong</h1>
+      <p>{error.message}</p>
+      {/* reset function tells the app to try rendering the component again */}
+      <Button onClick={() => reset()}>Try again</Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Next.js global error boundary page (`src/app/error.tsx`) that catches unhandled runtime errors and presents the user with a friendly message and a retry option.

## Changes

### `src/app/error.tsx` (new file)
- `'use client'` directive — required by Next.js for `error.tsx` segments
- Receives `error: Error` and `reset: () => void` props from the Next.js error boundary
- Displays the error message and a **Try again** button that calls `reset()` to re-render the failed segment
- Uses the existing `Button` component from shadcn

## Behaviour
- On any unhandled render/data error within the app shell, Next.js automatically renders this page instead of a blank crash screen
- Clicking **Try again** retriggers the failed component tree without a full page reload
