### PR TITLE
Feature: Add login page with JWT auth and token expiry handling

### DIFF
--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -15,8 +15,9 @@ api.interceptors.request.use(
     if (token) {
       if (isTokenExpired(token)) {
         useAuthStore.getState().logout();
+      } else {
+        config.headers.Authorization = `Bearer ${token}`;
       }
-      config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -7,4 +7,17 @@ const api = axios.create({
   },
 });
 
+api.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('authToken');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -1,4 +1,6 @@
+import { isTokenExpired } from '@/utils/utils';
 import axios from 'axios';
+import { useAuthStore } from '@/store/auth-store';
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || '/api',
@@ -11,6 +13,9 @@ api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('authToken');
     if (token) {
+      if (isTokenExpired(token)) {
+        useAuthStore.getState().logout();
+      }
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;

--- a/frontend/src/app/login/forms-wrapper.tsx
+++ b/frontend/src/app/login/forms-wrapper.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useAuthStore } from '@/store/auth-store';
+import { useState } from 'react';
+import { LoginForm } from './login-form';
+
+function FormsWrapper() {
+  const { isLoggedIn } = useAuthStore();
+  const [showSignUp, setShowSignUp] = useState(false);
+
+  if (isLoggedIn) {
+    return <p>Already logged in</p>;
+  }
+
+  return showSignUp ? (
+    <div>
+      <h2>Sign Up</h2>
+    </div>
+  ) : (
+    <div>
+      <h2>Login</h2>
+      <LoginForm />
+      <p>
+        Don&apos;t have an account?{' '}
+        <button onClick={() => setShowSignUp(true)}>Sign Up</button>
+      </p>
+    </div>
+  );
+}
+
+export default FormsWrapper;

--- a/frontend/src/app/login/forms-wrapper.tsx
+++ b/frontend/src/app/login/forms-wrapper.tsx
@@ -3,6 +3,7 @@
 import { useAuthStore } from '@/store/auth-store';
 import { useState } from 'react';
 import { LoginForm } from './login-form';
+import { Button } from '@/components/custom/button';
 
 function FormsWrapper() {
   const { isLoggedIn } = useAuthStore();
@@ -12,18 +13,37 @@ function FormsWrapper() {
     return <p>Already logged in</p>;
   }
 
-  return showSignUp ? (
-    <div>
-      <h2>Sign Up</h2>
-    </div>
-  ) : (
-    <div>
-      <h2>Login</h2>
-      <LoginForm />
-      <p>
-        Don&apos;t have an account?{' '}
-        <button onClick={() => setShowSignUp(true)}>Sign Up</button>
-      </p>
+  return (
+    <div className='flex flex-col gap-2'>
+      {showSignUp ? (
+        <div>
+          <LoginForm formType='signup' />
+          <div className='flex items-center gap-2'>
+            <p>Already have an account? </p>
+            <Button
+              variant='link'
+              className='p-0'
+              onClick={() => setShowSignUp(false)}
+            >
+              Login
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <LoginForm formType='login' />
+          <div className='flex items-center gap-2'>
+            <p>Don&apos;t have an account? </p>
+            <Button
+              variant='link'
+              className='p-0'
+              onClick={() => setShowSignUp(true)}
+            >
+              Sign Up
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/login/forms-wrapper.tsx
+++ b/frontend/src/app/login/forms-wrapper.tsx
@@ -4,13 +4,14 @@ import { useAuthStore } from '@/store/auth-store';
 import { useState } from 'react';
 import { LoginForm } from './login-form';
 import { Button } from '@/components/custom/button';
+import { ProtectedContent } from './protected-content';
 
 function FormsWrapper() {
   const { isLoggedIn } = useAuthStore();
   const [showSignUp, setShowSignUp] = useState(false);
 
   if (isLoggedIn) {
-    return <p>Already logged in</p>;
+    return <ProtectedContent />;
   }
 
   return (

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -61,25 +61,10 @@ export function LoginForm({ formType }: LoginFormProps) {
   });
 
   function onSubmit(data: z.infer<typeof formSchema>) {
-    toast('You submitted the following values:', {
-      description: (
-        <pre className='bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4'>
-          <code>{JSON.stringify(data, null, 2)}</code>
-        </pre>
-      ),
-      position: 'bottom-right',
-      classNames: {
-        content: 'flex flex-col gap-2',
-      },
-      style: {
-        '--border-radius': 'calc(var(--radius)  + 4px)',
-      } as React.CSSProperties,
-    });
     const endpoint = formType === 'login' ? '/auth/signin' : '/auth/signup';
     api
       .post(endpoint, data)
       .then((response) => {
-        console.log(data);
         login(response.data.token);
         toast.success(
           `${formType === 'login' ? 'Login' : 'Sign Up'} successful`

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import api from '@/api/axios';
+import { zodResolver } from '@hookform/resolvers/zod';
+import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import * as z from 'zod';
+
+import { Button } from '@/components/shadcn/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/shadcn/card';
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/components/shadcn/field';
+import { Input } from '@/components/shadcn/input';
+import { useAuthStore } from '@/store/auth-store';
+
+const formSchema = z.object({
+  username: z
+    .string()
+    .min(3, 'Username must be at least 3 characters.')
+    .max(20, 'Username must be at most 20 characters.')
+    .regex(
+      /^[a-zA-Z0-9_]+$/,
+      'Username can only contain letters, numbers, and underscores.'
+    ),
+  password: z
+    .string()
+    .min(3, 'Password must be at least 3 characters.')
+    .max(100, 'Password must be at most 100 characters.')
+    .regex(
+      /^[a-zA-Z0-9_]+$/,
+      'Password can only contain letters, numbers, and underscores.'
+    ),
+});
+
+export function LoginForm() {
+  const { login } = useAuthStore();
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      username: '',
+      password: '',
+    },
+  });
+
+  function onSubmit(data: z.infer<typeof formSchema>) {
+    toast('You submitted the following values:', {
+      description: (
+        <pre className='bg-code text-code-foreground mt-2 w-[320px] overflow-x-auto rounded-md p-4'>
+          <code>{JSON.stringify(data, null, 2)}</code>
+        </pre>
+      ),
+      position: 'bottom-right',
+      classNames: {
+        content: 'flex flex-col gap-2',
+      },
+      style: {
+        '--border-radius': 'calc(var(--radius)  + 4px)',
+      } as React.CSSProperties,
+    });
+    api
+      .post('/auth/signin', data)
+      .then((response) => {
+        console.log(data);
+        login(response.data.token);
+        toast.success('Login successful');
+      })
+      .catch((error) => {
+        toast.error(`Failed to submit login: ${error.message}`);
+      });
+  }
+
+  return (
+    <Card className='w-full animate-zoom-in'>
+      <CardHeader>
+        <CardTitle>Login</CardTitle>
+        <CardDescription>Enter your credentials to log in</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form id='login-form' onSubmit={form.handleSubmit(onSubmit)}>
+          <FieldGroup>
+            <Controller
+              name='username'
+              control={form.control}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor='login-form-username'>
+                    Username
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    id='login-form-username'
+                    aria-invalid={fieldState.invalid}
+                    placeholder='Enter your username'
+                    autoComplete='off'
+                  />
+                  {fieldState.invalid && (
+                    <FieldError
+                      data-testid='login-form-username-error'
+                      errors={[fieldState.error]}
+                    />
+                  )}
+                </Field>
+              )}
+            />
+            <Controller
+              name='password'
+              control={form.control}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor='login-form-password'>
+                    Password
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    id='login-form-password'
+                    type='password'
+                    aria-invalid={fieldState.invalid}
+                    placeholder='••••••••'
+                    autoComplete='off'
+                  />
+                  {fieldState.invalid && (
+                    <FieldError
+                      data-testid='login-form-password-error'
+                      errors={[fieldState.error]}
+                    />
+                  )}
+                </Field>
+              )}
+            />
+          </FieldGroup>
+        </form>
+      </CardContent>
+      <CardFooter>
+        <Field orientation='horizontal'>
+          <Button type='submit' form='login-form'>
+            Submit
+          </Button>
+          <Button type='button' variant='outline' onClick={() => form.reset()}>
+            Reset
+          </Button>
+        </Field>
+      </CardFooter>
+    </Card>
+  );
+}
+
+LoginForm.displayName = 'LoginForm';
+export default LoginForm;

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -44,7 +44,13 @@ const formSchema = z.object({
     ),
 });
 
-export function LoginForm() {
+type AuthFormType = 'login' | 'signup';
+
+interface LoginFormProps {
+  formType: AuthFormType;
+}
+
+export function LoginForm({ formType }: LoginFormProps) {
   const { login } = useAuthStore();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -69,23 +75,32 @@ export function LoginForm() {
         '--border-radius': 'calc(var(--radius)  + 4px)',
       } as React.CSSProperties,
     });
+    const endpoint = formType === 'login' ? '/auth/signin' : '/auth/signup';
     api
-      .post('/auth/signin', data)
+      .post(endpoint, data)
       .then((response) => {
         console.log(data);
         login(response.data.token);
-        toast.success('Login successful');
+        toast.success(
+          `${formType === 'login' ? 'Login' : 'Sign Up'} successful`
+        );
       })
       .catch((error) => {
-        toast.error(`Failed to submit login: ${error.message}`);
+        toast.error(
+          `Failed to submit ${formType === 'login' ? 'login' : 'sign up'}: ${error.message}`
+        );
       });
   }
 
   return (
     <Card className='w-full animate-zoom-in'>
       <CardHeader>
-        <CardTitle>Login</CardTitle>
-        <CardDescription>Enter your credentials to log in</CardDescription>
+        <CardTitle>{formType === 'login' ? 'Login' : 'Sign Up'}</CardTitle>
+        <CardDescription>
+          {formType === 'login'
+            ? 'Login enables you to access additional features (WIP).'
+            : 'Create a new account'}
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <form id='login-form' onSubmit={form.handleSubmit(onSubmit)}>

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -65,7 +65,9 @@ export function LoginForm({ formType }: LoginFormProps) {
     api
       .post(endpoint, data)
       .then((response) => {
-        login(response.data.token);
+        if (formType === 'login') {
+          login(response.data.token);
+        }
         toast.success(
           `${formType === 'login' ? 'Login' : 'Sign Up'} successful`
         );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,7 @@
+import FormsWrapper from './forms-wrapper';
+
+function LoginPage() {
+  return <FormsWrapper />;
+}
+
+export default LoginPage;

--- a/frontend/src/app/login/protected-content.tsx
+++ b/frontend/src/app/login/protected-content.tsx
@@ -1,0 +1,21 @@
+import { useApi } from '@/api/use-api';
+
+function ProtectedContent() {
+  const { data, error, loading } = useApi<{ message: string }>(
+    `/auth/test/user`
+  );
+
+  return loading ? (
+    <p>Loading...</p>
+  ) : error ? (
+    <p>Error: {error.message}</p>
+  ) : (
+    <div>
+      <h2>Login Successful</h2>
+      <p className='text-quiet'>{data?.message}</p>
+    </div>
+  );
+}
+
+ProtectedContent.displayName = 'ProtectedContent';
+export { ProtectedContent };

--- a/frontend/src/app/login/protected-content.tsx
+++ b/frontend/src/app/login/protected-content.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useApi } from '@/api/use-api';
 
 function ProtectedContent() {

--- a/frontend/src/components/world/burger-menu.tsx
+++ b/frontend/src/components/world/burger-menu.tsx
@@ -50,6 +50,15 @@ const BurgerMenu = React.memo(() => {
           Author
         </DropdownMenuItem>
         <DropdownMenuItem
+          onClick={() => {
+            router.push('/login');
+          }}
+          className={textStyle}
+        >
+          <UserRoundIcon className={iconStyle} />
+          Login
+        </DropdownMenuItem>
+        <DropdownMenuItem
           onClick={() => router.push('/inquiry')}
           className={textStyle}
         >

--- a/frontend/src/components/world/burger-menu.tsx
+++ b/frontend/src/components/world/burger-menu.tsx
@@ -11,16 +11,20 @@ import {
   HomeIcon,
   UserRoundIcon,
   MessageCircleHeartIcon,
+  LogOutIcon,
+  LogInIcon,
 } from 'lucide-react';
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '../custom/button';
+import { useAuthStore } from '@/store/auth-store';
 
 const iconStyle = 'size-5 mr-2';
 const textStyle = 'text-lg';
 
 const BurgerMenu = React.memo(() => {
   const router = useRouter();
+  const { isLoggedIn, logout } = useAuthStore();
 
   return (
     <DropdownMenu>
@@ -50,21 +54,35 @@ const BurgerMenu = React.memo(() => {
           Author
         </DropdownMenuItem>
         <DropdownMenuItem
-          onClick={() => {
-            router.push('/login');
-          }}
-          className={textStyle}
-        >
-          <UserRoundIcon className={iconStyle} />
-          Login
-        </DropdownMenuItem>
-        <DropdownMenuItem
           onClick={() => router.push('/inquiry')}
           className={textStyle}
         >
           <MessageCircleHeartIcon className={iconStyle} />
           Inquiry
         </DropdownMenuItem>
+        {isLoggedIn && (
+          <DropdownMenuItem
+            onClick={() => {
+              router.push('/');
+              logout();
+            }}
+            className={textStyle}
+          >
+            <LogOutIcon className={iconStyle} />
+            Logout
+          </DropdownMenuItem>
+        )}
+        {!isLoggedIn && (
+          <DropdownMenuItem
+            onClick={() => {
+              router.push('/login');
+            }}
+            className={textStyle}
+          >
+            <LogInIcon className={iconStyle} />
+            Login
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/frontend/src/store/auth-store.ts
+++ b/frontend/src/store/auth-store.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type AuthState = {
+  token: string | null;
+  isLoggedIn: boolean;
+  login: (token: string) => void;
+  logout: () => void;
+};
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      token: null,
+      isLoggedIn: false,
+      login: (token) => {
+        localStorage.setItem('authToken', token);
+        set({ token, isLoggedIn: true });
+      },
+      logout: () => {
+        localStorage.removeItem('authToken');
+        set({ token: null, isLoggedIn: false });
+      },
+    }),
+    { name: 'auth-storage' } // persists to localStorage automatically
+  )
+);

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -74,10 +74,19 @@ export const getIndependentLabel = (country: ACCountry | null): string => {
 
 export const isTokenExpired = (token: string): boolean => {
   try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
+    const payload = decodeJwtToPayload(token);
+    if (typeof payload.exp !== 'number') return true;
     // exp is in seconds, convert to milliseconds for comparison
     return payload.exp * 1000 < Date.now();
   } catch {
     return true;
   }
 };
+
+function decodeJwtToPayload(token: string) {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+
+  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes));
+}

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -71,3 +71,13 @@ export const getIndependentLabel = (country: ACCountry | null): string => {
   }
   return 'N/A';
 };
+
+export const isTokenExpired = (token: string): boolean => {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    // exp is in seconds, convert to milliseconds for comparison
+    return payload.exp * 1000 < Date.now();
+  } catch {
+    return true;
+  }
+};


### PR DESCRIPTION
## Summary

Implements user authentication with JWT, including login/signup UI and client-side token expiry handling.

## Changes

- **Auth store** (`auth-store.ts`): Zustand store with `persist` middleware to manage `isLoggedIn`, `token`, `login()`, and `logout()` state across page refreshes
- **Login form**: Login page with form UI; shows/hides based on `isLoggedIn` state from auth store
- **Signup form**: Signup form component
- **Logout**: Logout option added to burger menu
- **Axios interceptors** (`axios.ts`):
  - Request interceptor: decodes JWT client-side using `isTokenExpired()` — proactively logs out before making a request if token is expired
- **`isTokenExpired` utility** (`utils.ts`): Decodes JWT payload and compares `exp * 1000` against `Date.now()`

## Auth Flow

- Public endpoints work without any token
- Protected endpoints receive `Authorization: Bearer <token>` header automatically
- Expired tokens are caught both client-side (before request) and server-side (via 401 response)
