### PR TITLE
Feature: Switch auth from username to email address

### DIFF
--- a/backend/src/main/java/io/sotaro/backend/configuration/OpenApiConfig.java
+++ b/backend/src/main/java/io/sotaro/backend/configuration/OpenApiConfig.java
@@ -1,0 +1,24 @@
+package io.sotaro.backend.configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "World API", version = "v1"),
+        security = @SecurityRequirement(name = "bearerAuth") // global default
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
+)
+public class OpenApiConfig {
+}

--- a/backend/src/main/java/io/sotaro/backend/configuration/SecurityConfig.java
+++ b/backend/src/main/java/io/sotaro/backend/configuration/SecurityConfig.java
@@ -20,6 +20,7 @@ public class SecurityConfig {
     private final CustomCorsConfiguration customCorsConfiguration;
     private final AuthEntryPointJwt unauthorizedHandler;
     private final AuthTokenFilter authTokenFilter;
+    private final String[] PROTECTED_ENDPOINTS = {"/api/auth/test/user", "/api/user/**"};
 
     public SecurityConfig(
             CustomCorsConfiguration customCorsConfiguration,
@@ -55,7 +56,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
-                                .requestMatchers("/api/auth/test/user").authenticated()
+                                .requestMatchers(PROTECTED_ENDPOINTS).authenticated()
                                 .anyRequest().permitAll()
                 );
         // Add the JWT Token filter before the UsernamePasswordAuthenticationFilter

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -32,7 +32,8 @@ public class AuthController {
     public ResponseEntity<TokenDto> authenticateUser(@Valid @RequestBody UserSignInDto user) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
-                        user.username(),
+                        // Use mail address instead of username
+                        user.mail(),
                         user.password()
                 )
         );
@@ -40,20 +41,21 @@ public class AuthController {
         TokenDto tokenDto = new TokenDto(
                 jwtUtil.generateToken(userDetails.getUsername()),
                 "Bearer",
-                userDetails.getUsername()
+                userDetails.getUsername() // Return mail address instead of username
                 );
         return ResponseEntity.ok(tokenDto);
     }
     @PostMapping("/signup")
     public ResponseEntity<MessageDto> registerUser(@Valid @RequestBody UserSignInDto user) {
-        if (userRepository.existsByUsername(user.username())) {
-            MessageDto messageDto = new MessageDto("Error: Username is already taken!");
+        if (userRepository.existsByMail(user.mail())) {
+            MessageDto messageDto = new MessageDto("Error: Mail address is already taken!");
             return ResponseEntity.badRequest().body(messageDto);
         }
         // Create new user's account
         UserEntity newUserEntity = new UserEntity(
                 null,
-                user.username(),
+                user.mail(),
+                null,
                 encoder.encode(user.password())
         );
         userRepository.save(newUserEntity);

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -28,7 +28,7 @@ public class AuthController {
     @Autowired
     JwtUtil jwtUtil;
 
-    @PostMapping("/signin")
+    @PostMapping("/login")
     public ResponseEntity<TokenDto> authenticateUser(@Valid @RequestBody UserSignInDto user) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(

--- a/backend/src/main/java/io/sotaro/backend/controller/UserController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/UserController.java
@@ -1,8 +1,7 @@
 package io.sotaro.backend.controller;
 
 import io.sotaro.backend.model.UserDto;
-import io.sotaro.backend.model.UserEntity;
-import io.sotaro.backend.repository.UserRepository;
+import io.sotaro.backend.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -13,21 +12,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 public class UserController {
-    private final UserRepository userRepository;
+    private final UserService userService;
 
-    public UserController(UserRepository userRepository) {
-        this.userRepository = userRepository;
+    public UserController(UserService userService) {
+        this.userService = userService;
     }
 
     @GetMapping("/user")
     public ResponseEntity<UserDto> getCurrentUser(@AuthenticationPrincipal UserDetails userDetails) {
         // Get mail address from UserDetails
         String mail = userDetails.getUsername();
-        UserEntity userEntity = userRepository.findByMail(mail);
-        UserDto userDto = new UserDto(
-                userEntity.getMail(),
-                userEntity.getUsername()
-        );
+        UserDto userDto = userService.getCurrentUser(mail);
         return ResponseEntity.ok(userDto);
     }
 }

--- a/backend/src/main/java/io/sotaro/backend/controller/UserController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/UserController.java
@@ -1,0 +1,33 @@
+package io.sotaro.backend.controller;
+
+import io.sotaro.backend.model.UserDto;
+import io.sotaro.backend.model.UserEntity;
+import io.sotaro.backend.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class UserController {
+    private final UserRepository userRepository;
+
+    public UserController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<UserDto> getCurrentUser(@AuthenticationPrincipal UserDetails userDetails) {
+        // Get mail address from UserDetails
+        String mail = userDetails.getUsername();
+        UserEntity userEntity = userRepository.findByMail(mail);
+        UserDto userDto = new UserDto(
+                userEntity.getMail(),
+                userEntity.getUsername()
+        );
+        return ResponseEntity.ok(userDto);
+    }
+}

--- a/backend/src/main/java/io/sotaro/backend/exception/MailNotFoundException.java
+++ b/backend/src/main/java/io/sotaro/backend/exception/MailNotFoundException.java
@@ -1,0 +1,10 @@
+package io.sotaro.backend.exception;
+
+
+import org.springframework.security.core.AuthenticationException;
+
+public class MailNotFoundException extends AuthenticationException {
+    public MailNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/io/sotaro/backend/model/TokenDto.java
+++ b/backend/src/main/java/io/sotaro/backend/model/TokenDto.java
@@ -3,6 +3,6 @@ package io.sotaro.backend.model;
 public record TokenDto(
         String token,
         String type,
-        String username
+        String mail
 ) {
 }

--- a/backend/src/main/java/io/sotaro/backend/model/UserDto.java
+++ b/backend/src/main/java/io/sotaro/backend/model/UserDto.java
@@ -1,0 +1,17 @@
+package io.sotaro.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserDto(
+
+        @Schema(description = "User's email address", example = "test@test.com")
+        @NotBlank
+        @Email()
+        String mail,
+
+        @Schema(description = "User's name", example = "John Doe")
+        @Email()
+        String username
+){}

--- a/backend/src/main/java/io/sotaro/backend/model/UserEntity.java
+++ b/backend/src/main/java/io/sotaro/backend/model/UserEntity.java
@@ -15,6 +15,9 @@ public class UserEntity {
     private Long id;
 
     @Column(nullable = false, unique = true, length = 20)
+    private String mail;
+
+    @Column(unique = true, length = 20)
     private String username;
 
     @Column(nullable = false, length = 100)

--- a/backend/src/main/java/io/sotaro/backend/model/UserSignInDto.java
+++ b/backend/src/main/java/io/sotaro/backend/model/UserSignInDto.java
@@ -5,9 +5,9 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record UserSignInDto (
+        // Email regex from OWASP Validation Regex Repository
         @NotBlank
-//        @Size(min = 3, max = 20)
-//        @Pattern(regexp = "^[\\x20-\\x7E]+$", message = "Username must contain only ASCII characters")
+        @Pattern(regexp = "^[a-zA-Z0-9_+&*-] + (?:\\\\.[a-zA-Z0-9_+&*-] + )*@(?:[a-zA-Z0-9-]+\\\\.) + [a-zA-Z]{2,7}", message = "Invalid email format")
         String mail,
         @NotBlank
         @Size(min = 3, max = 100)

--- a/backend/src/main/java/io/sotaro/backend/model/UserSignInDto.java
+++ b/backend/src/main/java/io/sotaro/backend/model/UserSignInDto.java
@@ -6,9 +6,9 @@ import jakarta.validation.constraints.Size;
 
 public record UserSignInDto (
         @NotBlank
-        @Size(min = 3, max = 20)
-        @Pattern(regexp = "^[\\x20-\\x7E]+$", message = "Username must contain only ASCII characters")
-        String username,
+//        @Size(min = 3, max = 20)
+//        @Pattern(regexp = "^[\\x20-\\x7E]+$", message = "Username must contain only ASCII characters")
+        String mail,
         @NotBlank
         @Size(min = 3, max = 100)
         @Pattern(regexp = "^[\\x20-\\x7E]+$", message = "Password must contain only ASCII characters")

--- a/backend/src/main/java/io/sotaro/backend/model/UserSignInDto.java
+++ b/backend/src/main/java/io/sotaro/backend/model/UserSignInDto.java
@@ -1,14 +1,19 @@
 package io.sotaro.backend.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record UserSignInDto (
-        // Email regex from OWASP Validation Regex Repository
+
+        @Schema(description = "User's email address", example = "test@test.com")
         @NotBlank
-        @Pattern(regexp = "^[a-zA-Z0-9_+&*-] + (?:\\\\.[a-zA-Z0-9_+&*-] + )*@(?:[a-zA-Z0-9-]+\\\\.) + [a-zA-Z]{2,7}", message = "Invalid email format")
+        @Email()
         String mail,
+
+        @Schema(description = "User's password", example = "test1")
         @NotBlank
         @Size(min = 3, max = 100)
         @Pattern(regexp = "^[\\x20-\\x7E]+$", message = "Password must contain only ASCII characters")

--- a/backend/src/main/java/io/sotaro/backend/repository/UserRepository.java
+++ b/backend/src/main/java/io/sotaro/backend/repository/UserRepository.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
-    UserEntity findByUsername(String username);
-    boolean existsByUsername(String username);
+    UserEntity findByMail(String mail);
+    boolean existsByMail(String mail);
 }

--- a/backend/src/main/java/io/sotaro/backend/security/AuthTokenFilter.java
+++ b/backend/src/main/java/io/sotaro/backend/security/AuthTokenFilter.java
@@ -31,7 +31,7 @@ public class AuthTokenFilter extends OncePerRequestFilter {
         try {
             String jwt = parseJwt(request);
             if (jwt != null && jwtUtil.validateJwtToken(jwt)) {
-                String username = jwtUtil.getUsernameFromToken(jwt);
+                String username = jwtUtil.getMailFromToken(jwt);
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(

--- a/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
+++ b/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
@@ -26,16 +26,16 @@ public class JwtUtil {
         this.key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
     }
     // Generate JWT token
-    public String generateToken(String username) {
+    public String generateToken(String mail) {
         return Jwts.builder()
-                .setSubject(username)
+                .setSubject(mail)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
-    // Get username from JWT token
-    public String getUsernameFromToken(String token) {
+    // Get mail address from JWT token
+    public String getMailFromToken(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()

--- a/backend/src/main/java/io/sotaro/backend/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/io/sotaro/backend/service/CustomUserDetailsService.java
@@ -4,6 +4,7 @@ import io.sotaro.backend.exception.MailNotFoundException;
 import io.sotaro.backend.model.UserEntity;
 import io.sotaro.backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         if (userEntity == null) {
             throw new MailNotFoundException("User Not Found by mail address: " + mail);
         }
-        return new org.springframework.security.core.userdetails.User(
+        return new User(
                 userEntity.getMail(),
                 userEntity.getPassword(),
                 Collections.emptyList()

--- a/backend/src/main/java/io/sotaro/backend/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/io/sotaro/backend/service/CustomUserDetailsService.java
@@ -1,24 +1,27 @@
 package io.sotaro.backend.service;
 
+import io.sotaro.backend.exception.MailNotFoundException;
 import io.sotaro.backend.model.UserEntity;
 import io.sotaro.backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.*;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
+
 import java.util.Collections;
 
 @Service
-public class CustomUserDetailsService  implements UserDetailsService {
+public class CustomUserDetailsService implements UserDetailsService {
     @Autowired
     private UserRepository userRepository;
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        UserEntity userEntity = userRepository.findByUsername(username);
+    public UserDetails loadUserByUsername(String mail) throws MailNotFoundException {
+        UserEntity userEntity = userRepository.findByMail(mail);
         if (userEntity == null) {
-            throw new UsernameNotFoundException("User Not Found with username: " + username);
+            throw new MailNotFoundException("User Not Found by mail address: " + mail);
         }
         return new org.springframework.security.core.userdetails.User(
-                userEntity.getUsername(),
+                userEntity.getMail(),
                 userEntity.getPassword(),
                 Collections.emptyList()
         );

--- a/backend/src/main/java/io/sotaro/backend/service/UserService.java
+++ b/backend/src/main/java/io/sotaro/backend/service/UserService.java
@@ -1,0 +1,23 @@
+package io.sotaro.backend.service;
+
+import io.sotaro.backend.model.UserDto;
+import io.sotaro.backend.model.UserEntity;
+import io.sotaro.backend.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserDto getCurrentUser(String mail) {
+        UserEntity userEntity = userRepository.findByMail(mail);
+        return new UserDto(
+                userEntity.getMail(),
+                userEntity.getUsername()
+        );
+    }
+}

--- a/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
@@ -17,7 +17,7 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
 
     private final String BASE_URI = "/api/auth";
     private final String SIGNUP_URI = BASE_URI + "/signup";
-    private final String SIGNIN_URI = BASE_URI + "/signin";
+    private final String LOGIN_URI = BASE_URI + "/login";
     private final String AUTH_TEST_URI = BASE_URI + "/test/user";
 
     @Nested
@@ -52,16 +52,16 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
     }
 
     @Nested
-    class Signin {
+    class Login {
         @Test
-        void whenSigninWithValidCredentials_thenReturnJwtToken() throws Exception {
+        void whenLoginWithValidCredentials_thenReturnJwtToken() throws Exception {
             String requestBody = """
                     {
                         "mail": "example1@test.com",
                         "password": "password1"
                     }
                     """;
-            MvcResult result = mockMvc.perform(post(SIGNIN_URI)
+            MvcResult result = mockMvc.perform(post(LOGIN_URI)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(requestBody))
                     .andExpect(status().isOk())
@@ -72,14 +72,14 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
         }
 
         @Test
-        void whenSigninWithInvalidCredentials_thenReturnUnauthorized() throws Exception {
+        void whenLoginWithInvalidCredentials_thenReturnUnauthorized() throws Exception {
             String requestBody = """
                     {
                         "mail": "example1@test.com",
                         "password": "wrongpassword"
                     }
                     """;
-            mockMvc.perform(post(SIGNIN_URI)
+            mockMvc.perform(post(LOGIN_URI)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(requestBody))
                     .andExpect(status().isUnauthorized());
@@ -96,14 +96,14 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
 
         @Test
         void whenAccessProtectedEndpointWithValidToken_thenReturnOk() throws Exception {
-            // First, sign in to get a valid JWT token
+            // First, log in to get a valid JWT token
             String requestBody = """
                     {
                         "mail": "example1@test.com",
                         "password": "password1"
                     }
                     """;
-            MvcResult result = mockMvc.perform(post(SIGNIN_URI)
+            MvcResult result = mockMvc.perform(post(LOGIN_URI)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(requestBody))
                     .andExpect(status().isOk())

--- a/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
@@ -26,8 +26,8 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
         void whenSignupWithValidCredentials_thenReturnOk() throws Exception {
             String requestBody = """
                     {
-                        "username": "newuser",
-                        "password": "newpassword"
+                        "mail": "new@test.com",
+                        "password": "new-password"
                     }
                     """;
             mockMvc.perform(post(SIGNUP_URI)
@@ -37,10 +37,10 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
         }
 
         @Test
-        void whenSignupWithExistingUsername_thenReturnBadRequest() throws Exception {
+        void whenSignupWithExistingMail_thenReturnBadRequest() throws Exception {
             String requestBody = """
                     {
-                        "username": "user1",
+                        "mail": "example1@test.com",
                         "password": "password1"
                     }
                     """;
@@ -57,7 +57,7 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
         void whenSigninWithValidCredentials_thenReturnJwtToken() throws Exception {
             String requestBody = """
                     {
-                        "username": "user1",
+                        "mail": "example1@test.com",
                         "password": "password1"
                     }
                     """;
@@ -75,7 +75,7 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
         void whenSigninWithInvalidCredentials_thenReturnUnauthorized() throws Exception {
             String requestBody = """
                     {
-                        "username": "testuser",
+                        "mail": "example1@test.com",
                         "password": "wrongpassword"
                     }
                     """;
@@ -99,7 +99,7 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
             // First, sign in to get a valid JWT token
             String requestBody = """
                     {
-                        "username": "user1",
+                        "mail": "example1@test.com",
                         "password": "password1"
                     }
                     """;

--- a/backend/src/test/resources/test_populate_users.sql
+++ b/backend/src/test/resources/test_populate_users.sql
@@ -1,4 +1,4 @@
 INSERT INTO Users (
-  username, password
+  mail, username, password
 ) VALUES
-('user1', '$2a$10$VDLq0HP.9NkRE/IG9lSPwuebJPm.DV5Exfr4JOUx6HxWmK/OwYYa6');
+('example1@test.com', 'user1', '$2a$10$VDLq0HP.9NkRE/IG9lSPwuebJPm.DV5Exfr4JOUx6HxWmK/OwYYa6');

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -2,7 +2,6 @@
 
 import api from '@/api/axios';
 import { zodResolver } from '@hookform/resolvers/zod';
-import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import * as z from 'zod';
@@ -26,14 +25,7 @@ import { Input } from '@/components/shadcn/input';
 import { useAuthStore } from '@/store/auth-store';
 
 const formSchema = z.object({
-  username: z
-    .string()
-    .min(3, 'Username must be at least 3 characters.')
-    .max(20, 'Username must be at most 20 characters.')
-    .regex(
-      /^[a-zA-Z0-9_]+$/,
-      'Username can only contain letters, numbers, and underscores.'
-    ),
+  mail: z.email('Invalid email address'),
   password: z
     .string()
     .min(3, 'Password must be at least 3 characters.')
@@ -55,7 +47,7 @@ export function LoginForm({ formType }: LoginFormProps) {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      username: '',
+      mail: '',
       password: '',
     },
   });
@@ -93,23 +85,22 @@ export function LoginForm({ formType }: LoginFormProps) {
         <form id='login-form' onSubmit={form.handleSubmit(onSubmit)}>
           <FieldGroup>
             <Controller
-              name='username'
+              name='mail'
               control={form.control}
               render={({ field, fieldState }) => (
                 <Field data-invalid={fieldState.invalid}>
-                  <FieldLabel htmlFor='login-form-username'>
-                    Username
-                  </FieldLabel>
+                  <FieldLabel htmlFor='login-form-mail'>Email</FieldLabel>
                   <Input
                     {...field}
-                    id='login-form-username'
+                    id='login-form-mail'
+                    type='email'
                     aria-invalid={fieldState.invalid}
-                    placeholder='Enter your username'
+                    placeholder='Enter your email address'
                     autoComplete='off'
                   />
                   {fieldState.invalid && (
                     <FieldError
-                      data-testid='login-form-username-error'
+                      data-testid='login-form-mail-error'
                       errors={[fieldState.error]}
                     />
                   )}

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -53,7 +53,7 @@ export function LoginForm({ formType }: LoginFormProps) {
   });
 
   function onSubmit(data: z.infer<typeof formSchema>) {
-    const endpoint = formType === 'login' ? '/auth/signin' : '/auth/signup';
+    const endpoint = formType === 'login' ? '/auth/login' : '/auth/signup';
     api
       .post(endpoint, data)
       .then((response) => {

--- a/frontend/src/components/world/burger-menu.tsx
+++ b/frontend/src/components/world/burger-menu.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '../custom/button';
 import { useAuthStore } from '@/store/auth-store';
+import { toast } from 'sonner';
 
 const iconStyle = 'size-5 mr-2';
 const textStyle = 'text-lg';
@@ -65,6 +66,7 @@ const BurgerMenu = React.memo(() => {
             onClick={() => {
               router.push('/');
               logout();
+              toast.success('Logout successful');
             }}
             className={textStyle}
           >

--- a/world-db/db-init/init.sql
+++ b/world-db/db-init/init.sql
@@ -35,6 +35,7 @@ CREATE TABLE Airports (
 
 CREATE TABLE Users (
   id SERIAL PRIMARY KEY,
-  username TEXT NOT NULL UNIQUE,
+  mail TEXT NOT NULL UNIQUE,
+  username TEXT UNIQUE,
   password TEXT NOT NULL
 );

--- a/world-db/db-init/populate_users.sql
+++ b/world-db/db-init/populate_users.sql
@@ -1,0 +1,3 @@
+INSERT INTO Users (mail, username, password) VALUES
+('user@test.com', 'test-user', '$2a$10$XX8C/AuxtuMclX5XsbaVkO3w2e4ITcvVDq80Lqp.IXw80En.7dD5K');
+-- The password above is 'user' for testing purpose.

--- a/world-db/db-init/populate_users.sql
+++ b/world-db/db-init/populate_users.sql
@@ -1,3 +1,3 @@
 INSERT INTO Users (mail, username, password) VALUES
-('user@test.com', 'test-user', '$2a$10$XX8C/AuxtuMclX5XsbaVkO3w2e4ITcvVDq80Lqp.IXw80En.7dD5K');
+('user@test.com', 'John Doe', '$2a$10$XX8C/AuxtuMclX5XsbaVkO3w2e4ITcvVDq80Lqp.IXw80En.7dD5K');
 -- The password above is 'user' for testing purpose.


### PR DESCRIPTION
## Summary

Replaces username-based authentication with email address, and cleans up the auth-related backend endpoints.

## Changes

### Backend
- **Use email for auth**: Login now accepts email address instead of username (`UserSignInDto` updated)
- **Validation**: Added input validation for `UserSignInDto`
- **Swagger UI**: Enabled authentication support in Swagger UI
- **User endpoint**: Added `/user` endpoint
- **Refactor `UserController`**: Cleaned up controller structure
- **Rename endpoint**: `signin` → `login`

### Frontend
- **Login form**: Adjusted login form field from username to email address
