### PR TITLE
Feature: Switch JWT storage from localStorage to HttpOnly cookie

### DIFF
--- a/backend/src/main/java/io/sotaro/backend/configuration/CustomCorsConfiguration.java
+++ b/backend/src/main/java/io/sotaro/backend/configuration/CustomCorsConfiguration.java
@@ -16,6 +16,7 @@ public class CustomCorsConfiguration implements CorsConfigurationSource {
                 "http://localhost:3000", "https://world.sotaro.dev"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
         return config;
     }
 }

--- a/backend/src/main/java/io/sotaro/backend/configuration/OpenApiConfig.java
+++ b/backend/src/main/java/io/sotaro/backend/configuration/OpenApiConfig.java
@@ -11,14 +11,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(title = "World API", version = "v1"),
-        security = @SecurityRequirement(name = "bearerAuth") // global default
+        security = @SecurityRequirement(name = "cookieAuth")
 )
 @SecurityScheme(
-        name = "bearerAuth",
-        type = SecuritySchemeType.HTTP,
-        scheme = "bearer",
-        bearerFormat = "JWT",
-        in = SecuritySchemeIn.HEADER
+        name = "cookieAuth",
+        type = SecuritySchemeType.APIKEY,
+        in = SecuritySchemeIn.COOKIE,
+        paramName = "jwtToken"
 )
 public class OpenApiConfig {
 }

--- a/backend/src/main/java/io/sotaro/backend/configuration/SecurityConfig.java
+++ b/backend/src/main/java/io/sotaro/backend/configuration/SecurityConfig.java
@@ -47,9 +47,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
-                // CSRF protection is required for POST, PUT, DELETE requests
-                .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                // CSRF cookie is required for POST, PUT, DELETE requests
+                .csrf(csrf ->
+                        csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                         .ignoringRequestMatchers(CSRF_DEACTIVATED_ENDPOINTS)
                 )
                 .cors(c -> c.configurationSource(customCorsConfiguration))

--- a/backend/src/main/java/io/sotaro/backend/configuration/SecurityConfig.java
+++ b/backend/src/main/java/io/sotaro/backend/configuration/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
     private final AuthEntryPointJwt unauthorizedHandler;
     private final AuthTokenFilter authTokenFilter;
     private final String[] CSRF_DEACTIVATED_ENDPOINTS = {"/api/auth/login", "/api/auth/signup"};
-    private final String[] PROTECTED_ENDPOINTS = {"/api/auth/test/user", "/api/user/**"};
+    private final String[] PROTECTED_ENDPOINTS = {"/api/auth/test/protected", "/api/user/**"};
 
     public SecurityConfig(
             CustomCorsConfiguration customCorsConfiguration,

--- a/backend/src/main/java/io/sotaro/backend/configuration/SecurityConfig.java
+++ b/backend/src/main/java/io/sotaro/backend/configuration/SecurityConfig.java
@@ -7,12 +7,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 public class SecurityConfig {
@@ -20,6 +20,7 @@ public class SecurityConfig {
     private final CustomCorsConfiguration customCorsConfiguration;
     private final AuthEntryPointJwt unauthorizedHandler;
     private final AuthTokenFilter authTokenFilter;
+    private final String[] CSRF_DEACTIVATED_ENDPOINTS = {"/api/auth/login", "/api/auth/signup"};
     private final String[] PROTECTED_ENDPOINTS = {"/api/auth/test/user", "/api/user/**"};
 
     public SecurityConfig(
@@ -46,7 +47,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
-                .csrf(AbstractHttpConfigurer::disable)
+                // CSRF protection is required for POST, PUT, DELETE requests
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .ignoringRequestMatchers(CSRF_DEACTIVATED_ENDPOINTS)
+                )
                 .cors(c -> c.configurationSource(customCorsConfiguration))
                 .exceptionHandling(exceptionHandling ->
                         exceptionHandling.authenticationEntryPoint(unauthorizedHandler)

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -50,8 +50,8 @@ public class AuthController {
         cookie.setHttpOnly(true);
         if (isCookieSecure) { cookie.setSecure(true);}
         cookie.setPath("/");
-        // Set cookie max age slightly longer than JWT expiration time to ensure the cookie is removed after JWT expires
-        cookie.setMaxAge(jwtUtil.getExpirationInSecond() + 60);
+        // Align cookie max age with JWT expiration time (in seconds)
+        cookie.setMaxAge(jwtUtil.getExpirationInSecond());
         response.addCookie(cookie);
         return ResponseEntity.ok(new JwtLifespanDto(jwtUtil.getExpireAtEpochMs(token)));
     }

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -1,15 +1,17 @@
 package io.sotaro.backend.controller;
 
 import io.sotaro.backend.model.MessageDto;
-import io.sotaro.backend.model.TokenDto;
 import io.sotaro.backend.model.UserEntity;
 import io.sotaro.backend.model.UserSignInDto;
 import io.sotaro.backend.repository.UserRepository;
 import io.sotaro.backend.security.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.*;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,7 +31,7 @@ public class AuthController {
     JwtUtil jwtUtil;
 
     @PostMapping("/login")
-    public ResponseEntity<TokenDto> authenticateUser(@Valid @RequestBody UserSignInDto user) {
+    public ResponseEntity<MessageDto> authenticateUser(@Valid @RequestBody UserSignInDto user, HttpServletResponse response) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         // Use mail address instead of username
@@ -38,13 +40,28 @@ public class AuthController {
                 )
         );
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        TokenDto tokenDto = new TokenDto(
-                jwtUtil.generateToken(userDetails.getUsername()),
-                "Bearer",
-                userDetails.getUsername() // Return mail address instead of username
-                );
-        return ResponseEntity.ok(tokenDto);
+        String token = jwtUtil.generateToken(userDetails.getUsername());
+        Cookie cookie = new Cookie("jwtToken", token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60 * 24); // 1 day
+        response.addCookie(cookie);
+        return ResponseEntity.ok(new MessageDto("User login successfully!"));
     }
+
+    @GetMapping("/logout")
+    public ResponseEntity<MessageDto> logout(@CookieValue(value = "jwtToken", required = false) String jwtToken, HttpServletResponse response) {
+        if (jwtToken == null) {
+            return ResponseEntity.badRequest().body(new MessageDto("Log out failed, since you are not logged in!"));
+        }
+        Cookie cookie = new Cookie("jwtToken", "");
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+        return ResponseEntity.ok(new MessageDto("Log out successfully!"));
+    }
+
     @PostMapping("/signup")
     public ResponseEntity<MessageDto> registerUser(@Valid @RequestBody UserSignInDto user) {
         if (userRepository.existsByMail(user.mail())) {

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -46,7 +46,8 @@ public class AuthController {
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
-        cookie.setMaxAge(60 * 60 * 24); // 1 day
+        // Set cookie max age slightly longer than JWT expiration time to ensure the cookie is removed after JWT expires
+        cookie.setMaxAge(jwtUtil.getExpirationInSecond() + 60);
         response.addCookie(cookie);
         return ResponseEntity.ok(new JwtLifespanDto(jwtUtil.getExpireAtEpochMs(token)));
     }

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
         // Align cookie max age with JWT expiration time (in seconds)
         cookie.setMaxAge(jwtUtil.getExpirationInSecond());
         response.addCookie(cookie);
-        return ResponseEntity.ok(new JwtLifespanDto(jwtUtil.getExpireAtEpochMs(token)));
+        return ResponseEntity.ok(new JwtLifespanDto(jwtUtil.getExpiresAtEpochMs(token)));
     }
 
     @GetMapping("/logout")

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -57,11 +57,10 @@ public class AuthController {
     }
 
     @GetMapping("/logout")
-    public ResponseEntity<MessageDto> logout(@CookieValue(value = "jwtToken", required = false) String jwtToken, HttpServletResponse response) {
-        if (jwtToken == null) {
-            return ResponseEntity.badRequest().body(new MessageDto("Log out failed, since you are not logged in!"));
-        }
+    public ResponseEntity<MessageDto> logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("jwtToken", "");
+        cookie.setHttpOnly(true);
+        if (isCookieSecure) { cookie.setSecure(true); }
         cookie.setPath("/");
         cookie.setMaxAge(0);
         response.addCookie(cookie);

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -17,10 +17,14 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.beans.factory.annotation.Value;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
+
+    @Value("${custom.cookie.secure:true}")
+    private boolean isCookieSecure;
 
     @Autowired
     AuthenticationManager authenticationManager;
@@ -44,7 +48,7 @@ public class AuthController {
         String token = jwtUtil.generateToken(userDetails.getUsername());
         Cookie cookie = new Cookie("jwtToken", token);
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+        if (isCookieSecure) { cookie.setSecure(true);}
         cookie.setPath("/");
         // Set cookie max age slightly longer than JWT expiration time to ensure the cookie is removed after JWT expires
         cookie.setMaxAge(jwtUtil.getExpirationInSecond() + 60);

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -82,7 +82,7 @@ public class AuthController {
         return ResponseEntity.ok(messageDto);
     }
 
-    @GetMapping("/test/user")
+    @GetMapping("/test/protected")
     public ResponseEntity<MessageDto> userAccess() {
         MessageDto messageDto = new MessageDto("Only authenticated users can see this.");
         return ResponseEntity.ok(messageDto);

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -1,5 +1,6 @@
 package io.sotaro.backend.controller;
 
+import io.sotaro.backend.model.JwtLifespanDto;
 import io.sotaro.backend.model.MessageDto;
 import io.sotaro.backend.model.UserEntity;
 import io.sotaro.backend.model.UserSignInDto;
@@ -31,7 +32,7 @@ public class AuthController {
     JwtUtil jwtUtil;
 
     @PostMapping("/login")
-    public ResponseEntity<MessageDto> authenticateUser(@Valid @RequestBody UserSignInDto user, HttpServletResponse response) {
+    public ResponseEntity<JwtLifespanDto> authenticateUser(@Valid @RequestBody UserSignInDto user, HttpServletResponse response) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         // Use mail address instead of username
@@ -47,7 +48,7 @@ public class AuthController {
         cookie.setPath("/");
         cookie.setMaxAge(60 * 60 * 24); // 1 day
         response.addCookie(cookie);
-        return ResponseEntity.ok(new MessageDto("User login successfully!"));
+        return ResponseEntity.ok(new JwtLifespanDto(jwtUtil.getExpireAtEpochMs(token)));
     }
 
     @GetMapping("/logout")

--- a/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
+++ b/backend/src/main/java/io/sotaro/backend/controller/AuthController.java
@@ -57,10 +57,7 @@ public class AuthController {
     }
 
     @GetMapping("/logout")
-    public ResponseEntity<MessageDto> logout(@CookieValue(value = "jwtToken", required = false) String jwtToken, HttpServletResponse response) {
-        if (jwtToken == null) {
-            return ResponseEntity.badRequest().body(new MessageDto("Log out failed, since you are not logged in!"));
-        }
+    public ResponseEntity<MessageDto> logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("jwtToken", "");
         cookie.setPath("/");
         cookie.setMaxAge(0);

--- a/backend/src/main/java/io/sotaro/backend/model/JwtLifespanDto.java
+++ b/backend/src/main/java/io/sotaro/backend/model/JwtLifespanDto.java
@@ -1,0 +1,6 @@
+package io.sotaro.backend.model;
+
+public record JwtLifespanDto(
+        long expiresAtEpochMs
+) {
+}

--- a/backend/src/main/java/io/sotaro/backend/model/TokenDto.java
+++ b/backend/src/main/java/io/sotaro/backend/model/TokenDto.java
@@ -1,8 +1,0 @@
-package io.sotaro.backend.model;
-
-public record TokenDto(
-        String token,
-        String type,
-        String mail
-) {
-}

--- a/backend/src/main/java/io/sotaro/backend/model/UserSignInDto.java
+++ b/backend/src/main/java/io/sotaro/backend/model/UserSignInDto.java
@@ -8,12 +8,12 @@ import jakarta.validation.constraints.Size;
 
 public record UserSignInDto (
 
-        @Schema(description = "User's email address", example = "test@test.com")
+        @Schema(description = "User's email address", example = "user@test.com")
         @NotBlank
         @Email()
         String mail,
 
-        @Schema(description = "User's password", example = "test1")
+        @Schema(description = "User's password", example = "user")
         @NotBlank
         @Size(min = 3, max = 100)
         @Pattern(regexp = "^[\\x20-\\x7E]+$", message = "Password must contain only ASCII characters")

--- a/backend/src/main/java/io/sotaro/backend/security/AuthTokenFilter.java
+++ b/backend/src/main/java/io/sotaro/backend/security/AuthTokenFilter.java
@@ -3,16 +3,18 @@ package io.sotaro.backend.security;
 import io.sotaro.backend.service.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.authentication.*;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+
 import java.io.IOException;
 
 @Slf4j
@@ -30,6 +32,9 @@ public class AuthTokenFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         try {
             String jwt = parseJwt(request);
+            if (jwt == null) {
+                log.debug("No JWT token found in request");
+            }
             if (jwt != null && jwtUtil.validateJwtToken(jwt)) {
                 String username = jwtUtil.getMailFromToken(jwt);
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);
@@ -48,10 +53,15 @@ public class AuthTokenFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
     private String parseJwt(HttpServletRequest request) {
-        String headerAuth = request.getHeader("Authorization");
-        if (headerAuth != null && headerAuth.startsWith("Bearer ")) {
-            return headerAuth.substring(7);
+        String jwtToken = null;
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("jwtToken".equals(cookie.getName())) {
+                    jwtToken = cookie.getValue();
+                    break;
+                }
+            }
         }
-        return null;
+        return jwtToken;
     }
 }

--- a/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
+++ b/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
@@ -53,6 +53,9 @@ public class JwtUtil {
                 .toInstant().toEpochMilli();
         return issuedAt + jwtExpirationMs;
     }
+    public int getExpirationInSecond() {
+        return jwtExpirationMs / 1000;
+    }
     // Validate JWT token
     public boolean validateJwtToken(String token) {
         try {

--- a/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
+++ b/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
@@ -44,14 +44,14 @@ public class JwtUtil {
                 .getSubject();
     }
     public long getExpireAtEpochMs(String token) {
-        long issuedAt = Jwts.parserBuilder()
+        return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
-                .getIssuedAt()
-                .toInstant().toEpochMilli();
-        return issuedAt + jwtExpirationMs;
+                .getExpiration()
+                .toInstant()
+                .toEpochMilli();
     }
     public int getExpirationInSecond() {
         return jwtExpirationMs / 1000;

--- a/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
+++ b/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
@@ -43,6 +43,16 @@ public class JwtUtil {
                 .getBody()
                 .getSubject();
     }
+    public long getExpireAtEpochMs(String token) {
+        long issuedAt = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getIssuedAt()
+                .toInstant().toEpochMilli();
+        return issuedAt + jwtExpirationMs;
+    }
     // Validate JWT token
     public boolean validateJwtToken(String token) {
         try {

--- a/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
+++ b/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
@@ -43,7 +43,7 @@ public class JwtUtil {
                 .getBody()
                 .getSubject();
     }
-    public long getExpireAtEpochMs(String token) {
+    public long getExpiresAtEpochMs(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()

--- a/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
+++ b/backend/src/main/java/io/sotaro/backend/security/JwtUtil.java
@@ -54,7 +54,7 @@ public class JwtUtil {
                 .toEpochMilli();
     }
     public int getExpirationInSecond() {
-        return jwtExpirationMs / 1000;
+        return Math.toIntExact(Math.floorDiv((long) jwtExpirationMs + 999, 1000));
     }
     // Validate JWT token
     public boolean validateJwtToken(String token) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -42,6 +42,8 @@ custom:
   jwt:
     token:
       secret: ${JWT_SECRET:thisIsMysecregtfrdesww233eggtffeeddgkjjhhtdhttebd54ndhdhfhhhshs8877465sbbdd}
+  cookie:
+    secure: false
 
 ---
 spring:
@@ -56,9 +58,12 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     show-sql: false
-jwt:
-  token:
-    secret: ${JWT_SECRET}
+custom:
+  jwt:
+    token:
+      secret: ${JWT_SECRET}
+  cookie:
+    secure: true
 
 ---
 

--- a/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
@@ -63,12 +63,13 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
                     }
                     """;
             MvcResult result = mockMvc.perform(post(LOGIN_URI)
+                            .secure(true)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(requestBody))
                     .andExpect(status().isOk())
                     .andExpect(cookie().exists("jwtToken"))
-                    .andExpect(cookie().secure("jwtToken", true))
                     .andExpect(cookie().httpOnly("jwtToken", true))
+                    .andExpect(cookie().secure("jwtToken", true))
                     .andReturn();
 
             String responseContent = result.getResponse().getContentAsString();
@@ -113,7 +114,7 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
                     .andExpect(status().isOk())
                     .andReturn();
 
-            // Now, access the protected endpoint with the token
+            // Now, access the protected endpoint with the token in cookie
             mockMvc.perform(get(AUTH_TEST_URI)
                             .cookie(result.getResponse().getCookie("jwtToken")))
                             .andExpect(status().isOk());

--- a/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Sql(scripts = "/test_populate_users.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
@@ -54,7 +55,7 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
     @Nested
     class Login {
         @Test
-        void whenLoginWithValidCredentials_thenReturnJwtToken() throws Exception {
+        void whenLoginWithValidCredentials_thenReturnJwtTokenInCookie() throws Exception {
             String requestBody = """
                     {
                         "mail": "example1@test.com",
@@ -65,10 +66,13 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(requestBody))
                     .andExpect(status().isOk())
+                    .andExpect(cookie().exists("jwtToken"))
+                    .andExpect(cookie().secure("jwtToken", true))
+                    .andExpect(cookie().httpOnly("jwtToken", true))
                     .andReturn();
 
             String responseContent = result.getResponse().getContentAsString();
-            assertTrue(responseContent.contains("token"));
+            assertTrue(responseContent.contains("expiresAtEpochMs"));
         }
 
         @Test
@@ -109,13 +113,10 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
                     .andExpect(status().isOk())
                     .andReturn();
 
-            String contentAsString = result.getResponse().getContentAsString();
-            String token = objectMapper.readTree(contentAsString).get("token").asText();
-
             // Now, access the protected endpoint with the token
             mockMvc.perform(get(AUTH_TEST_URI)
-                            .header("Authorization", "Bearer " + token))
-                    .andExpect(status().isOk());
+                            .cookie(result.getResponse().getCookie("jwtToken")))
+                            .andExpect(status().isOk());
 
         }
 

--- a/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/io/sotaro/backend/controller/AuthControllerIntegrationTest.java
@@ -19,7 +19,7 @@ public class AuthControllerIntegrationTest extends BaseSecurityIntegrationTest {
     private final String BASE_URI = "/api/auth";
     private final String SIGNUP_URI = BASE_URI + "/signup";
     private final String LOGIN_URI = BASE_URI + "/login";
-    private final String AUTH_TEST_URI = BASE_URI + "/test/user";
+    private final String AUTH_TEST_URI = BASE_URI + "/test/protected";
 
     @Nested
     class Signup {

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -25,4 +25,4 @@ custom:
       secret: thisIsMysecregtfrdesww233eggtffeeddgkjjhhtdhttebd54ndhdhfhhhshs8877465sbbdd
       expiration: 300000
   cookie:
-    secure: false
+    secure: true

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -24,3 +24,5 @@ custom:
     token:
       secret: thisIsMysecregtfrdesww233eggtffeeddgkjjhhtdhttebd54ndhdhfhhhshs8877465sbbdd
       expiration: 300000
+  cookie:
+    secure: false

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -8,6 +8,7 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 });
 
 api.interceptors.request.use(

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -13,8 +13,8 @@ const api = axios.create({
 
 api.interceptors.request.use(
   (config) => {
-    const expiresAtEpochMs = localStorage.getItem('expiresAtEpochMs');
-    if (expiresAtEpochMs && isTokenExpired(Number(expiresAtEpochMs))) {
+    const { expiresAtEpochMs } = useAuthStore.getState();
+    if (expiresAtEpochMs != null && isTokenExpired(expiresAtEpochMs)) {
       useAuthStore.getState().logout();
       toast.error('Session expired. Please log in again.');
     }

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -1,6 +1,7 @@
 import { isTokenExpired } from '@/utils/utils';
 import axios from 'axios';
 import { useAuthStore } from '@/store/auth-store';
+import { toast } from 'sonner';
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || '/api',
@@ -11,13 +12,10 @@ const api = axios.create({
 
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('authToken');
-    if (token) {
-      if (isTokenExpired(token)) {
-        useAuthStore.getState().logout();
-      } else {
-        config.headers.Authorization = `Bearer ${token}`;
-      }
+    const expiresAtEpochMs = localStorage.getItem('expiresAtEpochMs');
+    if (expiresAtEpochMs && isTokenExpired(Number(expiresAtEpochMs))) {
+      useAuthStore.getState().logout();
+      toast.error('Session expired. Please log in again.');
     }
     return config;
   },

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -58,7 +58,7 @@ export function LoginForm({ formType }: LoginFormProps) {
       .post(endpoint, data)
       .then((response) => {
         if (formType === 'login') {
-          login(response.data.token);
+          login(response.data.expiresAtEpochMs);
         }
         toast.success(
           `${formType === 'login' ? 'Login' : 'Sign Up'} successful`

--- a/frontend/src/app/login/protected-content.tsx
+++ b/frontend/src/app/login/protected-content.tsx
@@ -3,7 +3,7 @@ import { useApi } from '@/api/use-api';
 
 function ProtectedContent() {
   const { data, error, loading } = useApi<{ message: string }>(
-    `/auth/test/user`
+    `/auth/test/protected`
   );
 
   return loading ? (

--- a/frontend/src/components/world/burger-menu.tsx
+++ b/frontend/src/components/world/burger-menu.tsx
@@ -33,13 +33,11 @@ const BurgerMenu = React.memo(() => {
       .get('/auth/logout')
       .then(() => {
         toast.success('Logout successful');
+        logout();
+        router.push('/'); // Redirect to home page after logout
       })
       .catch((error) => {
         toast.error(`Failed to logout: ${error.message}`);
-      })
-      .finally(() => {
-        logout();
-        router.push('/'); // Redirect to home page after logout
       });
   }
 

--- a/frontend/src/components/world/burger-menu.tsx
+++ b/frontend/src/components/world/burger-menu.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/navigation';
 import { Button } from '../custom/button';
 import { useAuthStore } from '@/store/auth-store';
 import { toast } from 'sonner';
+import api from '@/api/axios';
 
 const iconStyle = 'size-5 mr-2';
 const textStyle = 'text-lg';
@@ -26,6 +27,21 @@ const textStyle = 'text-lg';
 const BurgerMenu = React.memo(() => {
   const router = useRouter();
   const { isLoggedIn, logout } = useAuthStore();
+
+  function onLogout() {
+    api
+      .get('/auth/logout')
+      .then(() => {
+        toast.success('Logout successful');
+      })
+      .catch((error) => {
+        toast.error(`Failed to logout: ${error.message}`);
+      })
+      .finally(() => {
+        logout();
+        router.push('/'); // Redirect to home page after logout
+      });
+  }
 
   return (
     <DropdownMenu>
@@ -62,14 +78,7 @@ const BurgerMenu = React.memo(() => {
           Inquiry
         </DropdownMenuItem>
         {isLoggedIn && (
-          <DropdownMenuItem
-            onClick={() => {
-              router.push('/');
-              logout();
-              toast.success('Logout successful');
-            }}
-            className={textStyle}
-          >
+          <DropdownMenuItem onClick={onLogout} className={textStyle}>
             <LogOutIcon className={iconStyle} />
             Logout
           </DropdownMenuItem>

--- a/frontend/src/store/auth-store.ts
+++ b/frontend/src/store/auth-store.ts
@@ -14,11 +14,9 @@ export const useAuthStore = create<AuthState>()(
       expiresAtEpochMs: null,
       isLoggedIn: false,
       login: (expiresAtEpochMs) => {
-        localStorage.setItem('expiresAtEpochMs', expiresAtEpochMs.toString());
         set({ expiresAtEpochMs, isLoggedIn: true });
       },
       logout: () => {
-        localStorage.removeItem('expiresAtEpochMs');
         set({ expiresAtEpochMs: null, isLoggedIn: false });
       },
     }),

--- a/frontend/src/store/auth-store.ts
+++ b/frontend/src/store/auth-store.ts
@@ -2,24 +2,24 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 type AuthState = {
-  token: string | null;
+  expiresAtEpochMs: number | null;
   isLoggedIn: boolean;
-  login: (token: string) => void;
+  login: (expiresAtEpochMs: number) => void;
   logout: () => void;
 };
 
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
-      token: null,
+      expiresAtEpochMs: null,
       isLoggedIn: false,
-      login: (token) => {
-        localStorage.setItem('authToken', token);
-        set({ token, isLoggedIn: true });
+      login: (expiresAtEpochMs) => {
+        localStorage.setItem('expiresAtEpochMs', expiresAtEpochMs.toString());
+        set({ expiresAtEpochMs, isLoggedIn: true });
       },
       logout: () => {
-        localStorage.removeItem('authToken');
-        set({ token: null, isLoggedIn: false });
+        localStorage.removeItem('expiresAtEpochMs');
+        set({ expiresAtEpochMs: null, isLoggedIn: false });
       },
     }),
     { name: 'auth-storage' } // persists to localStorage automatically

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -73,5 +73,5 @@ export const getIndependentLabel = (country: ACCountry | null): string => {
 };
 
 export const isTokenExpired = (expiresAtEpochMs: number): boolean => {
-  return expiresAtEpochMs < Date.now();
+  return Number.isNaN(expiresAtEpochMs) || expiresAtEpochMs < Date.now();
 };

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -72,21 +72,6 @@ export const getIndependentLabel = (country: ACCountry | null): string => {
   return 'N/A';
 };
 
-export const isTokenExpired = (token: string): boolean => {
-  try {
-    const payload = decodeJwtToPayload(token);
-    if (typeof payload.exp !== 'number') return true;
-    // exp is in seconds, convert to milliseconds for comparison
-    return payload.exp * 1000 < Date.now();
-  } catch {
-    return true;
-  }
+export const isTokenExpired = (expiresAtEpochMs: number): boolean => {
+  return expiresAtEpochMs < Date.now();
 };
-
-function decodeJwtToPayload(token: string) {
-  const base64Url = token.split('.')[1];
-  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-
-  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
-  return JSON.parse(new TextDecoder().decode(bytes));
-}


### PR DESCRIPTION
## Summary

Switches JWT authentication from `localStorage` to an HttpOnly cookie, improving security by preventing XSS-based token theft. Since the token is no longer accessible to JavaScript, `expiresAt` is now returned from the login endpoint so the client can still perform proactive expiry checks.

## Changes

### Backend
- **Switch to cookie JWT**: JWT is now set as an HttpOnly cookie on login instead of returned in the response body
- **Return `expiresAt`**: Login response now includes `expiresAt` (timestamp in ms) so the frontend can check expiry without decoding the token
- **Align cookie expiry with JWT expiry**: Cookie `Max-Age` is set to match the JWT expiration time
- **Update OpenAPI config**: Swagger UI description updated to reflect cookie-based auth
- **Update integration tests**: `AuthControllerIntegrationTest` adjusted for the new auth flow
- **Rename test endpoint**: `/user/access` → `/test/protected`

## Security Improvement

| Before | After |
|---|---|
| JWT in `localStorage` (readable by JS) | JWT in HttpOnly cookie (not accessible to JS) |
| Vulnerable to XSS token theft | XSS cannot steal the token |

## Notes

- The frontend axios interceptor no longer needs to manually attach `Authorization: Bearer` — the cookie is sent automatically by the browser
- Client-side expiry checking uses the `expiresAt` field from the login response stored in the auth store
